### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-provisioning-deployment.yml
+++ b/.github/workflows/contoso-traders-provisioning-deployment.yml
@@ -1,5 +1,9 @@
 name: contoso-traders-provisioning-deployment
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1368/devsecops/security/code-scanning/3](https://github.com/github-cloudlabsuser-1368/devsecops/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow (e.g., checking out code, logging into Azure, deploying resources, and seeding databases), the `contents: read` permission is sufficient for most steps, while specific steps may require additional permissions (e.g., `packages: write` for container registry login). We will start with a minimal permissions block and adjust as necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
