### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-app-deployment.yml
+++ b/.github/workflows/contoso-traders-app-deployment.yml
@@ -3,6 +3,9 @@ name: contoso-traders-app-deployment
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   ACR_NAME: contosotradersacr
   AKS_CLUSTER_NAME: contoso-traders-aks


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1368/devsecops/security/code-scanning/1](https://github.com/github-cloudlabsuser-1368/devsecops/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow primarily involves reading repository contents and does not require write access, the permissions can be limited to `contents: read`. This ensures that the workflow operates securely while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
